### PR TITLE
Separate test messages from debugger websocket.

### DIFF
--- a/src/Debugger/Debugger.lua
+++ b/src/Debugger/Debugger.lua
@@ -80,8 +80,6 @@ function P.init(endpoint)
 
     P.ws:connect()
 
-    print(P.ws)
-
     P.handles[P.initialize] = true
 
 end
@@ -197,10 +195,16 @@ function P._onWebsocketRecieve(message_type, message)
 
     local result, msg = xpcall(fn, debug.traceback)
 
-    if not result then
-        print(msg)
-    end
+    -- we want to forward the failure to the test if in test mode,
+    -- as it cannot detect the error that otherwise would be raised.
 
+    if ASEDEB.config.test_mode then
+        ASEDEB.testAssert(false, msg)
+    end
+    
+    if not result then
+        error(msg)
+    end
 end
 
 return P

--- a/src/Debugger/main.lua
+++ b/src/Debugger/main.lua
@@ -15,7 +15,6 @@ config_file:close()
 
 if ASEDEB.config.log_file then
     -- overload print function, as it otherwise prints to aseprites built in console.
-    print("BEFORE OUT")
     io.output(ASEDEB.config.log_file)
 
     function print(...)
@@ -28,8 +27,6 @@ if ASEDEB.config.log_file then
         io.flush()
 
     end
-
-    print("AFTER OUT")
 end
 
 -- load debugger package here, to make sure its source path matches up with the path used when giving script permissions.

--- a/src/Debugger/tests/initialize_test.lua
+++ b/src/Debugger/tests/initialize_test.lua
@@ -3,7 +3,7 @@ local Debugger = ASEDEB.Debugger
 Debugger.init()
 
 Debugger.onConnect(function()
-    testAssert(debug.gethook(), "Debugger hook was not set!")
-    testAssert(Debugger.handles[Debugger.initialize], "Initialize handle was not registered!")
+    ASEDEB.testAssert(debug.gethook() == Debugger._debugHook, "Debugger hook was not set!")
+    ASEDEB.testAssert(Debugger.handles[Debugger.initialize], "Initialize handle was not registered!")
+    ASEDEB.stopTest()
 end)
-

--- a/src/Tests/AsepriteDebuggerTest/AsepriteDebuggerTest.csproj
+++ b/src/Tests/AsepriteDebuggerTest/AsepriteDebuggerTest.csproj
@@ -9,6 +9,7 @@
     <IsTestProject>true</IsTestProject>
     <AssemblyVersion>1.0.0.21888</AssemblyVersion>
     <BaseOutputPath></BaseOutputPath>
+    <FileVersion>1.0.0.36955</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,9 +38,5 @@
 		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </Content>
   </ItemGroup>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="(cp $(SolutionDir)src/Debugger/Debugger.lua $(TargetDir) &amp;&amp; mkdir $(TargetDir)json &amp;&amp; cp $(SolutionDir)src/Debugger/json/json.lua $(TargetDir)json/json.lua) || true" />
-  </Target>
 
 </Project>

--- a/src/Tests/PrepareAseprite/PrepareAseprite.csproj
+++ b/src/Tests/PrepareAseprite/PrepareAseprite.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyVersion>1.0.0.39563</AssemblyVersion>
+    <FileVersion>1.0.0.34984</FileVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Avoid mixing mocking messages with test result verification messages by separating them in to two distinct websockets.