### PR TITLE
Temporary cpaths and better extension selection.

### DIFF
--- a/src/Debugger/Debugger.lua
+++ b/src/Debugger/Debugger.lua
@@ -1,4 +1,3 @@
-require '../LuaWebSocket'
 require 'JsonWS'
 
 ---@class Debugger

--- a/src/Debugger/main.lua
+++ b/src/Debugger/main.lua
@@ -33,20 +33,16 @@ end)
 -- this also prevents this workaround from affecting other scripts and extensions.
 local tmp_cpath = package.cpath
 
--- currently only windows allows loading of shared libraries,
--- so there is no reason to modify the shared library extension depending on platform
--- test mode is an exception for this though.
+-- use the loadall library extension as the shared library extension for the current platform.
+local shared_lib_ext = package.cpath:match(".+loadall%p(%a+)")
 
-local shared_lib_ext = "dll"
-
-if ASEDEB.config.test_mode then
-    shared_lib_ext = package.cpath:match("%p[\\|/]?%p(%a+)")
-end
 package.cpath = tmp_cpath .. ";" .. ASEDEB.ext_path .. "/?." .. shared_lib_ext
 
 print("before require")
 require 'LuaWebSocket'
 print("after require")
+
+print(package.cpath)
 
 package.cpath = tmp_cpath
 

--- a/src/Debugger/main.lua
+++ b/src/Debugger/main.lua
@@ -28,13 +28,21 @@ table.insert(package.searchers, function(module)
     return nil
 end)
 
+
 -- package.cpath seems to be preserved between aseprite runs, so we want to make sure to remove the custom search path.
 -- this also prevents this workaround from affecting other scripts and extensions.
 local tmp_cpath = package.cpath
 
 -- currently only windows allows loading of shared libraries,
 -- so there is no reason to modify the shared library extension depending on platform
-package.cpath = tmp_cpath .. ";" .. ASEDEB.ext_path .. "/?.dll"
+-- test mode is an exception for this though.
+
+local shared_lib_ext = "dll"
+
+if ASEDEB.config.test_mode then
+    shared_lib_ext = package.cpath:match("%p[\\|/]?%p(%a+)")
+end
+package.cpath = tmp_cpath .. ";" .. ASEDEB.ext_path .. "/?." .. shared_lib_ext
 
 print("before require")
 require 'LuaWebSocket'

--- a/src/Debugger/main.lua
+++ b/src/Debugger/main.lua
@@ -28,14 +28,19 @@ table.insert(package.searchers, function(module)
     return nil
 end)
 
--- determine shared library extension by examining existing values in the cpath and using their extensions.
-local shared_lib_ext = package.cpath:match("%p[\\|/]?%p(%a+)")
+-- package.cpath seems to be preserved between aseprite runs, so we want to make sure to remove the custom search path.
+-- this also prevents this workaround from affecting other scripts and extensions.
+local tmp_cpath = package.cpath
 
-package.cpath = package.cpath .. ";" .. ASEDEB.ext_path .. "/?." .. shared_lib_ext
+-- currently only windows allows loading of shared libraries,
+-- so there is no reason to modify the shared library extension depending on platform
+package.cpath = tmp_cpath .. ";" .. ASEDEB.ext_path .. "/?.dll"
 
 print("before require")
 require 'LuaWebSocket'
 print("after require")
+
+package.cpath = tmp_cpath
 
 -- configuration file should store the debug adapter endpoint, the debugger log file, and optionally test mode and test script.
 -- can be accessed through all scripts with the ASEDEB_CONFIG global.

--- a/src/Debugger/tests/receive_message.lua
+++ b/src/Debugger/tests/receive_message.lua
@@ -1,4 +1,3 @@
-require '../LuaWebSocket'
 require 'JsonWS'
 
 local ws = LuaWebSocket()

--- a/src/Debugger/tests/send_message.lua
+++ b/src/Debugger/tests/send_message.lua
@@ -1,4 +1,3 @@
-require '../LuaWebSocket'
 require 'JsonWS'
 
 print("OMG")


### PR DESCRIPTION
cpath is now temporarily modified instead of permanently, making sure no other scripts and extensions will have a modified cpath.
Shared library extension is now based on the loadall lib extension to improve consistency.