### PR TITLE
(#42) Wait until test connection is closed, before debugger connection is closed.

### DIFF
--- a/src/Debugger/Debugger.lua
+++ b/src/Debugger/Debugger.lua
@@ -58,7 +58,6 @@ end
 function P.init()
     while P._stopped or not P._launched do
         P.handleMessage(JsonWS.receiveJson(P.pipe_ws))
-        print("CONTINUE: ", P._stopped, not P._launched)
     end
 end
 
@@ -73,7 +72,6 @@ end
 ---@param args table
 ---@param response Response
 function P.initialize(args, response)
-    print("INITIALIZED")
     -- TODO: implement all marked as false.
     response:send({
         supportsConfigurationDoneRequest = true,
@@ -100,19 +98,15 @@ end
 ---@param args table
 ---@param response Response
 function P.configurationDone(args, response)
-    print("CONFIG DONE START")
     P._stopped = false
     response:send({})
-    print("CONFIG DONE END")
 end
 
 ---@param args table
 ---@param response Response
 function P.launch(args, response)
-    print("LAUNCH START")
     P._launched = true
     response:send({})
-    print("LAUNCH END")
 end
 
 --- Debugger only works with one thread, since lua has no multithreading (except maybe for asepite websockets?),

--- a/src/Debugger/tests/breakpoints_test.lua
+++ b/src/Debugger/tests/breakpoints_test.lua
@@ -21,7 +21,7 @@ function_1()
 
 ASEDEB.stopTest()
 ASEDEB.waitForServerStop()
-ASEDEB.deinit()
+ASEDEB.Debugger.deinit()
 
 --
 -- final comment line

--- a/src/Debugger/tests/log_message.lua
+++ b/src/Debugger/tests/log_message.lua
@@ -4,3 +4,5 @@ ASEDEB.Debugger.connect(ASEDEB.config.endpoint)
 print("!<TEST LOG MESSAGE>!")
 
 ASEDEB.stopTest()
+ASEDEB.waitForServerStop()
+ASEDEB.Debugger.deinit()

--- a/src/Debugger/tests/receive_message.lua
+++ b/src/Debugger/tests/receive_message.lua
@@ -6,5 +6,8 @@ ws:connect(ASEDEB.config.endpoint)
 
 JsonWS.sendJson(ws, { type = "test_message" })
 
-ws:close()
 ASEDEB.stopTest()
+
+ASEDEB.waitForServerStop()
+
+ws:close()

--- a/src/Debugger/tests/send_message.lua
+++ b/src/Debugger/tests/send_message.lua
@@ -12,5 +12,8 @@ ASEDEB.testAssert(
     "Received invalid message."
 )
 
-ws:close()
 ASEDEB.stopTest()
+
+ASEDEB.waitForServerStop()
+
+ws:close()


### PR DESCRIPTION
This is a potential fix for #42, where the debugger websocket connection is only closed once the test runner has received a test ended message from the debug script.
Previously, this would have resulted in the debugger connection closing too early leading to a fault (not quite sure what the actual error is or why it resulted in the debug script getting blocked).
